### PR TITLE
Migrate supported versions to Stonecutter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,69 @@
-# Automatically build the project and run any configured tests for every push
-# and submitted pull request. This can help catch issues that only occur on
-# certain platforms or Java versions, and provides a first line of defence
-# against bad commits.
-
 name: build
-on: [pull_request, push]
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 1.21.7
+  push:
+    branches:
+      - main
+      - 1.21.7
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  build-all:
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout repository
-        uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - name: setup jdk
-        uses: actions/setup-java@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'microsoft'
-      - name: make gradle wrapper executable
-        run: chmod +x ./gradlew
-      - name: build
-        run: ./gradlew build
-      - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+          java-version: "21"
+          distribution: temurin
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build and test every Minecraft version
+        run: ./gradlew --no-daemon build
+
+      - name: Verify runtime artifacts
+        shell: bash
+        run: |
+          for minecraft_version in 1.21.4 1.21.5 1.21.6 1.21.7; do
+            mapfile -t jars < <(find "versions/${minecraft_version}/build/libs" -maxdepth 1 -type f \
+              -name "paleolithic-era-${minecraft_version}-*.jar" ! -name "*-sources.jar")
+            if [[ ${#jars[@]} -ne 1 ]]; then
+              echo "Expected one runtime jar for ${minecraft_version}, found ${#jars[@]}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Capture build artifacts
+        uses: actions/upload-artifact@v7
         with:
-          name: Artifacts
-          path: build/libs/
+          name: paleolithic-era-${{ github.sha }}
+          path: |
+            versions/*/build/libs/paleolithic-era-*.jar
+            !versions/*/build/libs/*-sources.jar
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Capture failed test reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-${{ github.sha }}
+          path: versions/*/build/reports/tests/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ Notes:
 
 ## Testing
 
+### Multi-version workspace
+
+Paleolithic Era uses [Stonecutter](https://plugins.gradle.org/plugin/dev.kikugie.stonecutter) to maintain
+Minecraft 1.21.4, 1.21.5, 1.21.6, and 1.21.7 from one branch and one shared `src/` tree. Per-version dependency
+coordinates live under `versions/<minecraft-version>/gradle.properties`.
+
+Root verification tasks run against every supported version:
+
+```bash
+./gradlew build
+./gradlew testQuick
+```
+
+Qualify a task to work with one version:
+
+```bash
+./gradlew :1.21.7:build
+./gradlew :1.21.7:runClient
+./gradlew :1.21.7:runServer
+```
+
+Stonecutter conditionals in shared Kotlin sources are rewritten when the active development version changes:
+
+```bash
+./gradlew stonecutterSwitchTo1.21.4
+./gradlew stonecutterSwitchTo1.21.7
+```
+
+Minecraft 1.21.7 is the checked-in VCS version. Always switch back to it before committing. Run data generation only
+on that node (`./gradlew :1.21.7:runDatagen`) because every node shares `src/main/generated`; the older nodes'
+datagen tasks are disabled to prevent accidental cross-version overwrites.
+
 This project includes a comprehensive test suite to ensure reliability and prevent regressions. Tests are organized by priority levels and can be run individually or in groups.
 
 ### Test Priority Levels
@@ -211,6 +243,7 @@ The test suite is designed to work in CI environments:
 ## Developer Notes
 - **Mod ID:** `paleolithic-era`
 - **Language/Stack:** Fabric + Kotlin
+- **Versions:** Stonecutter builds Minecraft 1.21.4 through 1.21.7 from the shared source tree.
 - **Java:** JDK 21 is selected for both the Gradle daemon and compilation. Install any JDK 21 distribution and
   run builds through `./gradlew` (`gradlew.bat` on Windows); Gradle's checked-in daemon criteria will locate it
   even if `JAVA_HOME` points to a newer JDK.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import java.time.Duration
 
 plugins {
 	kotlin("jvm")
-	id("fabric-loom")
+	id("net.fabricmc.fabric-loom-remap")
 	id("maven-publish")
 	java
 }
@@ -25,6 +25,7 @@ version = property("mod_version")!!
 fabricApi {
 	configureDataGeneration {
 		client = true
+		outputDirectory = rootProject.file("src/main/generated")
 	}
 }
 
@@ -64,6 +65,11 @@ kotlin {
 tasks {
 
 	processResources {
+		dependsOn(project.tasks.matching { it.name == "stonecutterGenerate" })
+
+		// Fabric datagen's cache is build bookkeeping, not a runtime resource.
+		exclude(".cache/**")
+
 		// Ensure changes to these props re-run resource processing
 		inputs.property("version", project.version)
 		inputs.property("minecraft_version", minecraft_version)
@@ -85,7 +91,7 @@ tasks {
 	}
 
 	jar {
-		from("LICENSE")
+		from(rootProject.file("LICENSE"))
 		// Exclude test files from the jar to prevent bloating
 		exclude("**/test/**")
 		exclude("**/*Test.class")
@@ -99,6 +105,7 @@ tasks {
 	publishing {
 		publications {
 			create<MavenPublication>("mavenJava") {
+				artifactId = "${property("archives_base_name")}-${minecraft_version}"
 				artifact(remapJar) {
 					builtBy(remapJar)
 				}
@@ -252,4 +259,14 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+}
+
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+	systemProperty("paleolithic.minecraftVersion", minecraft_version)
+	systemProperty("paleolithic.loaderVersion", loader_version)
+}
+
+// Generated assets are shared by every node and are authored from the VCS version only.
+tasks.matching { it.name == "runDatagen" }.configureEach {
+	enabled = minecraft_version == "1.21.7"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,6 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.parallel=true
 
-# Fabric Properties
-# check these on https://fabricmc.net/develop
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.8
-loader_version=0.16.14
-loom_version=1.11-SNAPSHOT
-fabric_kotlin_version=1.13.5+kotlin.2.2.10
-# Fabric API
-fabric_version=0.129.0+1.21.7
-
 # Mod Properties
 mod_version=0.3.2
 maven_group=com.toolsandtaverns

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,14 +6,19 @@ pluginManagement {
 		mavenCentral()
 		gradlePluginPortal()
 	}
+}
 
-	val loom_version: String by settings
-	val fabric_kotlin_version: String by settings
-	plugins {
-		id("fabric-loom") version loom_version
-		id("org.jetbrains.kotlin.jvm") version
-				fabric_kotlin_version
-				.split("+kotlin.")[1] // Grabs the sentence after `+kotlin.`
-				.split("+")[0] // Ensures sentences like `+build.1` are ignored
+plugins {
+	id("dev.kikugie.stonecutter") version "0.9.6"
+}
+
+stonecutter {
+	kotlinController = true
+	centralScript = "build.gradle.kts"
+	create(rootProject) {
+		versions("1.21.4", "1.21.5", "1.21.6", "1.21.7")
+		vcsVersion = "1.21.7"
 	}
 }
+
+rootProject.name = "paleolithic-era"

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/PaleolithicEraClient.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/PaleolithicEraClient.kt
@@ -26,11 +26,18 @@ import com.toolsandtaverns.paleolithicera.screen.KnappingStationScreen
 import com.toolsandtaverns.paleolithicera.screen.GroundStorageScreen
 import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry
+//? if >=1.21.6 {
 import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap
+//?} else {
+/*import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap*///?}
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry
+import net.minecraft.block.Block
 import net.minecraft.client.gui.screen.ingame.HandledScreens
+//? if >=1.21.6 {
 import net.minecraft.client.render.BlockRenderLayer
+//?} else {
+/*import net.minecraft.client.render.RenderLayer*///?}
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories
 
 /**
@@ -40,6 +47,13 @@ import net.minecraft.client.render.block.entity.BlockEntityRendererFactories
  * renderers, screens, and client-side network handlers.
  */
 object PaleolithicEraClient : ClientModInitializer {
+    private fun setCutout(block: Block) {
+        //? if >=1.21.6 {
+        BlockRenderLayerMap.putBlock(block, BlockRenderLayer.CUTOUT)
+        //?} else {
+        /*BlockRenderLayerMap.INSTANCE.putBlock(block, RenderLayer.getCutout())*///?}
+    }
+
     /**
      * Initializes the client-side components of the mod.
      *
@@ -95,19 +109,19 @@ object PaleolithicEraClient : ClientModInitializer {
 
         // Set the render layers for blocks with transparency
         // CUTOUT is used for blocks with binary transparency (fully transparent or fully opaque pixels)
-        BlockRenderLayerMap.putBlock(ModBlocks.CRUDE_CAMPFIRE, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.ELDERBERRY_BUSH, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.CHAMOMILE_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.YARROW_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILD_GARLIC_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.EPHEDRA_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.SAGEBRUSH_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILD_MINT_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILD_GINGER_PLANT, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILLOW_SAPLING, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILLOW_LEAF_VINES, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.WILLOW_LEAVES, BlockRenderLayer.CUTOUT)
-        BlockRenderLayerMap.putBlock(ModBlocks.EFFIGY_OF_PROTECTION, BlockRenderLayer.CUTOUT)
+        setCutout(ModBlocks.CRUDE_CAMPFIRE)
+        setCutout(ModBlocks.ELDERBERRY_BUSH)
+        setCutout(ModBlocks.CHAMOMILE_PLANT)
+        setCutout(ModBlocks.YARROW_PLANT)
+        setCutout(ModBlocks.WILD_GARLIC_PLANT)
+        setCutout(ModBlocks.EPHEDRA_PLANT)
+        setCutout(ModBlocks.SAGEBRUSH_PLANT)
+        setCutout(ModBlocks.WILD_MINT_PLANT)
+        setCutout(ModBlocks.WILD_GINGER_PLANT)
+        setCutout(ModBlocks.WILLOW_SAPLING)
+        setCutout(ModBlocks.WILLOW_LEAF_VINES)
+        setCutout(ModBlocks.WILLOW_LEAVES)
+        setCutout(ModBlocks.EFFIGY_OF_PROTECTION)
 
         // Register client-side network handlers for the harpoon fishing system
         OpenHarpoonGuiClient.register()

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/datagen/ModModelProvider.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/datagen/ModModelProvider.kt
@@ -55,8 +55,12 @@ class ModModelProvider(output: FabricDataOutput) : FabricModelProvider(output) {
                 .put(TextureKey.PARTICLE, id("block/hide_dryer_side"))
         }
 
+        //? if >1.21.4 {
         blockStateModelGenerator.createLogTexturePool(ModBlocks.WILLOW_LOG).log(ModBlocks.WILLOW_LOG)
         blockStateModelGenerator.createLogTexturePool(ModBlocks.STRIPPED_WILLOW_LOG).log(ModBlocks.STRIPPED_WILLOW_LOG)
+        //?} else {
+        /*blockStateModelGenerator.registerLog(ModBlocks.WILLOW_LOG).log(ModBlocks.WILLOW_LOG)
+        blockStateModelGenerator.registerLog(ModBlocks.STRIPPED_WILLOW_LOG).log(ModBlocks.STRIPPED_WILLOW_LOG)*///?}
 
         blockStateModelGenerator.registerSimpleCubeAll(ModBlocks.BUNDLE_OF_STICKS)
         blockStateModelGenerator.registerSimpleCubeAll(ModBlocks.WILLOW_PLANKS)
@@ -141,6 +145,7 @@ class ModModelProvider(output: FabricDataOutput) : FabricModelProvider(output) {
         block: Block,
         age: IntProperty = EdiblePlantBlock.AGE
     ) {
+        //? if >1.21.4 {
         this.blockStateCollector.accept(
             VariantsBlockModelDefinitionCreator.of(block).with(
                 BlockStateVariantMap.models(age).generate { stage: Int? ->
@@ -153,6 +158,17 @@ class ModModelProvider(output: FabricDataOutput) : FabricModelProvider(output) {
                     )
                 })
         )
+        //?} else {
+        /*val variants = BlockStateVariantMap.create(age).register { stage ->
+            val modelId = Models.CROSS.upload(
+                block,
+                "_stage$stage",
+                TextureMap.cross(ModelIds.getBlockSubModelId(block, "_stage$stage")),
+                this.modelCollector
+            )
+            BlockStateVariant.create().put(VariantSettings.MODEL, modelId)
+        }
+        this.blockStateCollector.accept(VariantsBlockStateSupplier.create(block).coordinate(variants))*///?}
     }
 
 }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoarAnimations.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoarAnimations.kt
@@ -1,6 +1,9 @@
 package com.toolsandtaverns.paleolithicera.model
 
+//? if >=1.21.6 {
 import net.minecraft.client.render.entity.animation.AnimationDefinition
+//?} else {
+/*import net.minecraft.client.render.entity.animation.Animation*///?}
 import net.minecraft.client.render.entity.animation.AnimationHelper
 import net.minecraft.client.render.entity.animation.Keyframe
 import net.minecraft.client.render.entity.animation.Transformation
@@ -12,7 +15,10 @@ import net.minecraft.client.render.entity.animation.Transformation
  */
 object BoarAnimations {
 
+    //? if >=1.21.6 {
     val idle: AnimationDefinition = AnimationDefinition.Builder.create(3.0f).looping()
+    //?} else {
+    /*val idle: Animation = Animation.Builder.create(3.0f).looping()*///?}
         .addBoneAnimation(
             "head", Transformation(
                 Transformation.Targets.ROTATE,
@@ -90,7 +96,10 @@ object BoarAnimations {
         )
         .build()
 
+    //? if >=1.21.6 {
     val walk: AnimationDefinition = AnimationDefinition.Builder.create(1.5f).looping()
+    //?} else {
+    /*val walk: Animation = Animation.Builder.create(1.5f).looping()*///?}
         .addBoneAnimation(
             "font_leg_l", Transformation(
                 Transformation.Targets.ROTATE,

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoarModel.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoarModel.kt
@@ -6,6 +6,9 @@ import net.minecraft.client.model.*
 import net.minecraft.client.render.entity.model.EntityModel
 import net.minecraft.client.render.entity.model.EntityModelLayer
 import net.minecraft.client.render.entity.model.ModelTransformer
+//? if <=1.21.4 {
+/*import net.minecraft.client.render.entity.animation.AnimationHelper
+import org.joml.Vector3f*///?}
 
 // Made with Blockbench 4.12.5
 // Exported for Minecraft version 1.17+ for Yarn
@@ -21,16 +24,40 @@ class BoarModel(root: ModelPart) : EntityModel<BoarRenderState>(root) {
     private val rear_leg_l: ModelPart = root.getChild("rear_leg_l")
     private val rear_leg_r: ModelPart = root.getChild("rear_leg_r")
 
+    //? if >=1.21.6 {
     private val walkingAnimation = BoarAnimations.walk.createAnimation(root)
     private val idlingAnimation = BoarAnimations.idle.createAnimation(root)
+    //?}
 
     override fun setAngles(state: BoarRenderState) {
         super.setAngles(state)
         this.head.pitch = state.pitch * (Math.PI.toFloat() / 180f)
+        //? if >1.21.4 {
         this.head.yaw = state.relativeHeadYaw * (Math.PI.toFloat() / 180f)
+        //? if <=1.21.4 {
+        /*this.head.yaw = state.yawDegrees * (Math.PI.toFloat() / 180f)*///?}
 
+        //? if >=1.21.6 {
         this.walkingAnimation.applyWalking(state.limbSwingAnimationProgress, state.limbSwingAmplitude, 2f, 2.5f)
         this.idlingAnimation.apply(state.idleAnimationState, state.age, 1f)
+        //?} else if >1.21.4 {
+        /*this.animateWalking(BoarAnimations.walk, state.limbSwingAnimationProgress, state.limbSwingAmplitude, 2f, 2.5f)
+        this.animate(state.idleAnimationState, BoarAnimations.idle, state.age, 1f)*///?}
+        //?} else {
+        /*AnimationHelper.animate(
+            this,
+            BoarAnimations.walk,
+            (state.limbFrequency * 50f * 2f).toLong(),
+            minOf(state.limbAmplitudeMultiplier * 2.5f, 1f),
+            Vector3f()
+        )
+        AnimationHelper.animate(
+            this,
+            BoarAnimations.idle,
+            state.idleAnimationState.getTimeInMilliseconds(state.age),
+            1f,
+            Vector3f()
+        )*///?}
     }
 
     companion object {
@@ -47,10 +74,10 @@ class BoarModel(root: ModelPart) : EntityModel<BoarRenderState>(root) {
                         .uv(0, 23).cuboid(-3.0f, -7.0f, -5.0f, 7.0f, 1.0f, 10.0f, Dilation(0.0f))
                         .uv(0, 42).cuboid(-2.0f, -8.0f, -4.0f, 5.0f, 1.0f, 6.0f, Dilation(0.0f))
                         .uv(0, 34).cuboid(-3.0f, 3.85f, -5.0f, 7.0f, 1.0f, 7.0f, Dilation(0.0f)),
-                    ModelTransform.origin(0.0f, 15.0f, 0.0f)
+                    origin(0.0f, 15.0f, 0.0f)
                 )
 
-                val tail = body.addChild("tail", ModelPartBuilder.create(), ModelTransform.origin(0.5f, -3.0f, 9.5f))
+                val tail = body.addChild("tail", ModelPartBuilder.create(), origin(0.5f, -3.0f, 9.5f))
 
                 tail.addChild(
                     "tail_r1",
@@ -62,11 +89,11 @@ class BoarModel(root: ModelPart) : EntityModel<BoarRenderState>(root) {
                     "head",
                     ModelPartBuilder.create().uv(34, 23).cuboid(-3.5f, -4.0f, -3.0f, 7.0f, 8.0f, 4.0f, Dilation(0.0f))
                         .uv(44, 0).cuboid(-2.0f, 0.0f, -6.0f, 4.0f, 3.0f, 3.0f, Dilation(0.0f)),
-                    ModelTransform.origin(0.5f, 14.0f, -7.0f)
+                    origin(0.5f, 14.0f, -7.0f)
                 )
 
                 val mouth =
-                    head.addChild("mouth", ModelPartBuilder.create(), ModelTransform.origin(-0.25f, 3.0f, -3.75f))
+                    head.addChild("mouth", ModelPartBuilder.create(), origin(-0.25f, 3.0f, -3.75f))
 
                 mouth.addChild(
                     "mouth_r1",
@@ -79,7 +106,7 @@ class BoarModel(root: ModelPart) : EntityModel<BoarRenderState>(root) {
                     "tusk",
                     ModelPartBuilder.create().uv(34, 46).cuboid(3.9f, -0.9f, -0.4f, 1.0f, 2.0f, 1.0f, Dilation(0.0f))
                         .uv(38, 46).cuboid(-0.1f, -0.9f, -0.4f, 1.0f, 2.0f, 1.0f, Dilation(0.0f)),
-                    ModelTransform.origin(-2.4f, 2.0f, -3.6f)
+                    origin(-2.4f, 2.0f, -3.6f)
                 )
 
                 tusk.addChild(
@@ -97,29 +124,36 @@ class BoarModel(root: ModelPart) : EntityModel<BoarRenderState>(root) {
                 modelPartData.addChild(
                     "font_leg_l",
                     ModelPartBuilder.create().uv(9, 50).cuboid(0.25f, 0.0f, -1.25f, 2.0f, 5.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(2.5f, 19.0f, -4.5f)
+                    origin(2.5f, 19.0f, -4.5f)
                 )
 
                 modelPartData.addChild(
                     "front_leg_r",
                     ModelPartBuilder.create().uv(9, 50).cuboid(-1.25f, 0.0f, -1.5f, 2.0f, 5.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(-2.5f, 19.0f, -4.25f)
+                    origin(-2.5f, 19.0f, -4.25f)
                 )
 
                 modelPartData.addChild(
                     "rear_leg_l",
                     ModelPartBuilder.create().uv(43, 6).cuboid(-2.0f, -1.0f, -1.0f, 3.0f, 3.0f, 3.0f, Dilation(0.0f))
                         .uv(0, 50).cuboid(-1.5f, 1.0f, -0.5f, 2.0f, 4.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(3.0f, 19.0f, 5.5f)
+                    origin(3.0f, 19.0f, 5.5f)
                 )
 
                 modelPartData.addChild(
                     "rear_leg_r",
                     ModelPartBuilder.create().uv(50, 12).cuboid(-1.0f, -1.0f, -1.0f, 3.0f, 3.0f, 3.0f, Dilation(0.0f))
                         .uv(0, 50).cuboid(-0.5f, 1.0f, -0.5f, 2.0f, 4.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(-2.0f, 19.0f, 5.5f)
+                    origin(-2.0f, 19.0f, 5.5f)
                 )
                 return TexturedModelData.of(modelData, 64, 64)
             }
+
+        private fun origin(x: Float, y: Float, z: Float): ModelTransform {
+            //? if >1.21.4 {
+            return ModelTransform.origin(x, y, z)
+            //?} else {
+            /*return ModelTransform.pivot(x, y, z)*///?}
+        }
     }
 }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoneSpearProjectileModel.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/BoneSpearProjectileModel.kt
@@ -18,7 +18,10 @@ class BoneSpearProjectileModel(root: ModelPart) : EntityModel<EntityRenderState>
                 modelData.root.addChild(
                     "main",
                     ModelPartBuilder.create().uv(0, 0).cuboid(-1.0F, -24.0F, 0.0F, 1.0F, 24.0F, 1.0F, Dilation(0.0f)),
+                    //? if >1.21.4 {
                     ModelTransform.origin(0.0f, 20f, 0.0f)
+                    //?} else {
+                    /*ModelTransform.pivot(0.0f, 20f, 0.0f)*///?}
                 )
                 return TexturedModelData.of(modelData, 64, 64)
             }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/IbexAnimations.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/IbexAnimations.kt
@@ -1,6 +1,12 @@
 package com.toolsandtaverns.paleolithicera.model
 
-import net.minecraft.client.render.entity.animation.*
+//? if >=1.21.6 {
+import net.minecraft.client.render.entity.animation.AnimationDefinition
+//?} else {
+/*import net.minecraft.client.render.entity.animation.Animation*///?}
+import net.minecraft.client.render.entity.animation.AnimationHelper
+import net.minecraft.client.render.entity.animation.Keyframe
+import net.minecraft.client.render.entity.animation.Transformation
 
 /**
  * Made with Blockbench 4.12.6
@@ -8,7 +14,10 @@ import net.minecraft.client.render.entity.animation.*
  * @author Author
  */
 object IbexAnimations {
+    //? if >=1.21.6 {
     val walk: AnimationDefinition = AnimationDefinition.Builder.create(1.0f).looping()
+    //?} else {
+    /*val walk: Animation = Animation.Builder.create(1.0f).looping()*///?}
         .addBoneAnimation(
             "front_leg_L", Transformation(
                 Transformation.Targets.ROTATE,

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/IbexModel.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/IbexModel.kt
@@ -7,6 +7,9 @@ import net.minecraft.client.model.*
 import net.minecraft.client.render.entity.model.EntityModel
 import net.minecraft.client.render.entity.model.EntityModelLayer
 import net.minecraft.client.render.entity.state.LivingEntityRenderState
+//? if <=1.21.4 {
+/*import net.minecraft.client.render.entity.animation.AnimationHelper
+import org.joml.Vector3f*///?}
 
 // Made with Blockbench 4.12.6
 // Exported for Minecraft version 1.17+ for Yarn
@@ -21,14 +24,30 @@ class IbexModel(root: ModelPart) : EntityModel<LivingEntityRenderState>(root) {
 //    private val bone: ModelPart = this.head.getChild("bone")
 //    private val bone2: ModelPart = this.head.getChild("bone2")
 
+    //? if >=1.21.6 {
     private val walkingAnimation = IbexAnimations.walk.createAnimation(root)
+    //?}
 
     override fun setAngles(state: LivingEntityRenderState) {
         super.setAngles(state)
         this.head.pitch = state.pitch * (Math.PI.toFloat() / 180f)
+        //? if >1.21.4 {
         this.head.yaw = state.relativeHeadYaw * (Math.PI.toFloat() / 180f)
+        //? if <=1.21.4 {
+        /*this.head.yaw = state.yawDegrees * (Math.PI.toFloat() / 180f)*///?}
 
+        //? if >=1.21.6 {
         this.walkingAnimation.applyWalking(state.limbSwingAnimationProgress, state.limbSwingAmplitude, 2f, 2.5f)
+        //?} else if >1.21.4 {
+        /*this.animateWalking(IbexAnimations.walk, state.limbSwingAnimationProgress, state.limbSwingAmplitude, 2f, 2.5f)*///?}
+        //?} else {
+        /*AnimationHelper.animate(
+            this,
+            IbexAnimations.walk,
+            (state.limbFrequency * 50f * 2f).toLong(),
+            minOf(state.limbAmplitudeMultiplier * 2.5f, 1f),
+            Vector3f()
+        )*///?}
     }
 
     companion object {
@@ -42,7 +61,7 @@ class IbexModel(root: ModelPart) : EntityModel<LivingEntityRenderState>(root) {
                     "body",
                     ModelPartBuilder.create().uv(0, 0).cuboid(-5.0f, -12.0f, -1.0f, 10.0f, 9.0f, 19.0f, Dilation(0.0f))
                         .uv(0, 28).cuboid(-2.0f, -13.0f, -3.0f, 4.0f, 11.0f, 9.0f, Dilation(0.0f)),
-                    ModelTransform.origin(0.0f, 22.0f, 0.0f)
+                    origin(0.0f, 22.0f, 0.0f)
                 )
 
                 body.addChild(
@@ -54,25 +73,25 @@ class IbexModel(root: ModelPart) : EntityModel<LivingEntityRenderState>(root) {
                 modelPartData.addChild(
                     "front_leg_L",
                     ModelPartBuilder.create().uv(0, 48).cuboid(-1.0f, -1.0f, -1.0f, 2.0f, 6.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(3.0f, 19.0f, 1.0f)
+                    origin(3.0f, 19.0f, 1.0f)
                 )
 
                 modelPartData.addChild(
                     "front_leg_R",
                     ModelPartBuilder.create().uv(8, 48).cuboid(-1.0f, -1.0f, -1.0f, 2.0f, 6.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(-3.0f, 19.0f, 1.0f)
+                    origin(-3.0f, 19.0f, 1.0f)
                 )
 
                 modelPartData.addChild(
                     "back_leg_R",
                     ModelPartBuilder.create().uv(16, 48).cuboid(-1.0f, -1.0f, -1.0f, 2.0f, 6.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(-3.0f, 19.0f, 16.0f)
+                    origin(-3.0f, 19.0f, 16.0f)
                 )
 
                 modelPartData.addChild(
                     "back_leg_L",
                     ModelPartBuilder.create().uv(50, 28).cuboid(-1.0f, -1.0f, -1.0f, 2.0f, 6.0f, 2.0f, Dilation(0.0f)),
-                    ModelTransform.origin(3.0f, 19.0f, 16.0f)
+                    origin(3.0f, 19.0f, 16.0f)
                 )
 
                 val head = modelPartData.addChild(
@@ -81,7 +100,7 @@ class IbexModel(root: ModelPart) : EntityModel<LivingEntityRenderState>(root) {
                         .uv(26, 42).cuboid(-2.0f, -2.0f, -10.0f, 4.0f, 4.0f, 6.0f, Dilation(0.0f))
                         .uv(16, 56).cuboid(-1.0f, 2.0f, -9.75f, 2.0f, 1.0f, 2.0f, Dilation(0.0f))
                         .uv(50, 40).cuboid(0.0f, 3.0f, -9.75f, 1.0f, 1.0f, 1.0f, Dilation(0.0f)),
-                    ModelTransform.origin(0.0f, 11.0f, -2.0f)
+                    origin(0.0f, 11.0f, -2.0f)
                 )
 
                 head.addChild(
@@ -151,5 +170,12 @@ class IbexModel(root: ModelPart) : EntityModel<LivingEntityRenderState>(root) {
                 )
                 return TexturedModelData.of(modelData, 128, 128)
             }
+
+        private fun origin(x: Float, y: Float, z: Float): ModelTransform {
+            //? if >1.21.4 {
+            return ModelTransform.origin(x, y, z)
+            //?} else {
+            /*return ModelTransform.pivot(x, y, z)*///?}
+        }
     }
 }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/WoodenSpearProjectileModel.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/model/WoodenSpearProjectileModel.kt
@@ -18,7 +18,10 @@ class WoodenSpearProjectileModel(root: ModelPart) : EntityModel<EntityRenderStat
                 modelData.root.addChild(
                     "main",
                     ModelPartBuilder.create().uv(0, 0).cuboid(-1.0F, -24.0F, 0.0F, 1.0F, 24.0F, 1.0F, Dilation(0.0f)),
+                    //? if >1.21.4 {
                     ModelTransform.origin(0.0f, 20f, 0.0f)
+                    //?} else {
+                    /*ModelTransform.pivot(0.0f, 20f, 0.0f)*///?}
                 )
                 return TexturedModelData.of(modelData, 64, 64)
             }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/CrudeCampfireBlockEntityRenderer.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/CrudeCampfireBlockEntityRenderer.kt
@@ -8,7 +8,10 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory
 import net.minecraft.client.render.item.ItemRenderer
 import net.minecraft.client.util.math.MatrixStack
+//? if >1.21.4 {
 import net.minecraft.item.ItemDisplayContext
+//?} else {
+/*import net.minecraft.item.ModelTransformationMode*///?}
 import net.minecraft.util.math.Direction
 import net.minecraft.util.math.RotationAxis
 import net.minecraft.util.math.Vec3d
@@ -42,8 +45,11 @@ class CrudeCampfireBlockEntityRenderer(
         matrices: MatrixStack?,
         vertexConsumers: VertexConsumerProvider?,
         light: Int,
+        //? if >1.21.4 {
         overlay: Int,
         cameraPos: Vec3d?
+        //?} else {
+        /*overlay: Int*///?}
     ) {
         // Safety check for null values
         if (entity.world == null || matrices == null || vertexConsumers == null) return
@@ -85,7 +91,10 @@ class CrudeCampfireBlockEntityRenderer(
             // Render the actual item
             itemRenderer.renderItem(
                 stack,                  // The item to render
+                //? if >1.21.4 {
                 ItemDisplayContext.FIXED, // Display as a fixed item in world
+                //?} else {
+                /*ModelTransformationMode.FIXED,*///?}
                 light,                  // Light level from the parameter
                 overlay,                // Overlay texture coordinates
                 matrices,               // Transformation matrix

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/FoodDryerBlockEntityRenderer.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/FoodDryerBlockEntityRenderer.kt
@@ -7,7 +7,10 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory
 import net.minecraft.client.render.item.ItemRenderer
 import net.minecraft.client.util.math.MatrixStack
+//? if >1.21.4 {
 import net.minecraft.item.ItemDisplayContext
+//?} else {
+/*import net.minecraft.item.ModelTransformationMode*///?}
 import net.minecraft.util.math.RotationAxis
 import net.minecraft.util.math.Vec3d
 import kotlin.math.sin
@@ -42,8 +45,11 @@ class FoodDryerBlockEntityRenderer(
         matrices: MatrixStack,
         vertexConsumers: VertexConsumerProvider,
         light: Int,
+        //? if >1.21.4 {
         overlay: Int,
         cameraPos: Vec3d?
+        //?} else {
+        /*overlay: Int*///?}
     ) {
         val renderData = entity.getRenderingData()
         if (renderData.isEmpty()) return
@@ -76,7 +82,10 @@ class FoodDryerBlockEntityRenderer(
             // Render the item
             itemRenderer.renderItem(
                 data.stack,
+                //? if >1.21.4 {
                 ItemDisplayContext.FIXED,
+                //?} else {
+                /*ModelTransformationMode.FIXED,*///?}
                 lightLevel,
                 overlay,
                 matrices,

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/KnappingStationBlockEntityRenderer.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/render/KnappingStationBlockEntityRenderer.kt
@@ -7,7 +7,10 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory
 import net.minecraft.client.render.item.ItemRenderer
 import net.minecraft.client.util.math.MatrixStack
+//? if >1.21.4 {
 import net.minecraft.item.ItemDisplayContext
+//?} else {
+/*import net.minecraft.item.ModelTransformationMode*///?}
 import net.minecraft.item.ItemStack
 import net.minecraft.util.math.RotationAxis
 import net.minecraft.util.math.Vec3d
@@ -27,8 +30,11 @@ class KnappingStationBlockEntityRenderer(
         matrices: MatrixStack,
         vertexConsumers: VertexConsumerProvider,
         light: Int,
+        //? if >1.21.4 {
         overlay: Int,
         cameraPos: Vec3d?
+        //?} else {
+        /*overlay: Int*///?}
     ) {
         val input: ItemStack = entity.getInventory().getStack(0)
         val output: ItemStack = entity.getInventory().getStack(1)
@@ -43,7 +49,10 @@ class KnappingStationBlockEntityRenderer(
             matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180f))
             itemRenderer.renderItem(
                 input,
+                //? if >1.21.4 {
                 ItemDisplayContext.FIXED,
+                //?} else {
+                /*ModelTransformationMode.FIXED,*///?}
                 lightLevel,
                 overlay,
                 matrices,
@@ -62,7 +71,10 @@ class KnappingStationBlockEntityRenderer(
             matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180f))
             itemRenderer.renderItem(
                 output,
+                //? if >1.21.4 {
                 ItemDisplayContext.FIXED,
+                //?} else {
+                /*ModelTransformationMode.FIXED,*///?}
                 lightLevel,
                 overlay,
                 matrices,

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/FoodDryerScreen.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/FoodDryerScreen.kt
@@ -1,12 +1,14 @@
 package com.toolsandtaverns.paleolithicera.screen
 
 import com.toolsandtaverns.paleolithicera.util.id
+//? if >=1.21.6 {
 import net.minecraft.client.gl.RenderPipelines
+//?}
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.ingame.HandledScreen
+import net.minecraft.client.render.RenderLayer
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.text.Text
-import net.minecraft.util.Colors
 import net.minecraft.util.Identifier
 
 /**
@@ -47,7 +49,10 @@ class FoodDryerScreen(
     override fun drawBackground(context: DrawContext, delta: Float, mouseX: Int, mouseY: Int) {
         // Draw main GUI background
         context.drawTexture(
+            //? if >=1.21.6 {
             RenderPipelines.GUI_TEXTURED,
+            //?} else {
+            /*RenderLayer::getGuiTextured,*///?}
             TEXTURE,
             x, y,
             0f, 0f,
@@ -63,7 +68,10 @@ class FoodDryerScreen(
                 
                 // Draw progress bar background
                 context.drawTexture(
+                    //? if >=1.21.6 {
                     RenderPipelines.GUI_TEXTURED,
+                    //?} else {
+                    /*RenderLayer::getGuiTextured,*///?}
                     TEXTURE,
                     x + progressX,
                     y + progressY,
@@ -74,7 +82,10 @@ class FoodDryerScreen(
                 
                 // Draw progress fill
                 context.drawTexture(
+                    //? if >=1.21.6 {
                     RenderPipelines.GUI_TEXTURED,
+                    //?} else {
+                    /*RenderLayer::getGuiTextured,*///?}
                     TEXTURE,
                     x + progressX,
                     y + progressY,
@@ -93,7 +104,7 @@ class FoodDryerScreen(
             title, 
             titleX, 
             titleY, 
-            Colors.DARK_GRAY, 
+            0x404040,
             false
         )
         
@@ -103,7 +114,7 @@ class FoodDryerScreen(
             playerInventory.displayName, 
             8, 
             playerInventoryTitleY, 
-            Colors.DARK_GRAY, 
+            0x404040,
             false
         )
     }

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/GroundStorageScreen.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/GroundStorageScreen.kt
@@ -4,7 +4,6 @@ import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.ingame.HandledScreen
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.text.Text
-import net.minecraft.util.Colors
 
 /** Client GUI for the eight-slot ground storage container. */
 class GroundStorageScreen(
@@ -85,8 +84,8 @@ class GroundStorageScreen(
     }
 
     override fun drawForeground(context: DrawContext, mouseX: Int, mouseY: Int) {
-        context.drawText(textRenderer, title, titleX, titleY, Colors.DARK_GRAY, false)
-        context.drawText(textRenderer, playerInventory.displayName, 8, playerInventoryTitleY, Colors.DARK_GRAY, false)
+        context.drawText(textRenderer, title, titleX, titleY, 0x404040, false)
+        context.drawText(textRenderer, playerInventory.displayName, 8, playerInventoryTitleY, 0x404040, false)
     }
 
     override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/HideDryerScreen.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/HideDryerScreen.kt
@@ -1,12 +1,14 @@
 package com.toolsandtaverns.paleolithicera.screen
 
 import com.toolsandtaverns.paleolithicera.util.id
+//? if >=1.21.6 {
 import net.minecraft.client.gl.RenderPipelines
+//?}
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.ingame.HandledScreen
+import net.minecraft.client.render.RenderLayer
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.text.Text
-import net.minecraft.util.Colors
 import net.minecraft.util.Identifier
 
 /**
@@ -35,7 +37,10 @@ class HideDryerScreen(
     override fun drawBackground(context: DrawContext, delta: Float, mouseX: Int, mouseY: Int) {
         // Draw background texture
         context.drawTexture(
+            //? if >=1.21.6 {
             RenderPipelines.GUI_TEXTURED,
+            //?} else {
+            /*RenderLayer::getGuiTextured,*///?}
             TEXTURE,
             x, y,
             0f, 0f,
@@ -47,7 +52,10 @@ class HideDryerScreen(
         val progressWidth = handler.getScaledProgress(PROGRESS_BAR_WIDTH)
         if (progressWidth > 0) {
             context.drawTexture(
+                //? if >=1.21.6 {
                 RenderPipelines.GUI_TEXTURED,
+                //?} else {
+                /*RenderLayer::getGuiTextured,*///?}
                 TEXTURE,
                 x + PROGRESS_BAR_X,
                 y + PROGRESS_BAR_Y,
@@ -59,7 +67,7 @@ class HideDryerScreen(
     }
 
     override fun drawForeground(context: DrawContext, mouseX: Int, mouseY: Int) {
-        context.drawText(textRenderer, title, titleX, titleY, Colors.DARK_GRAY, false)
+        context.drawText(textRenderer, title, titleX, titleY, 0x404040, false)
         context.drawText(textRenderer, playerInventory.displayName, 8, backgroundHeight - 94, 0x404040, false)
     }
 

--- a/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/KnappingStationScreen.kt
+++ b/src/client/kotlin/com/toolsandtaverns/paleolithicera/screen/KnappingStationScreen.kt
@@ -1,9 +1,12 @@
 package com.toolsandtaverns.paleolithicera.screen
 
 import com.toolsandtaverns.paleolithicera.util.id
+//? if >=1.21.6 {
 import net.minecraft.client.gl.RenderPipelines
+//?}
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.ingame.HandledScreen
+import net.minecraft.client.render.RenderLayer
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.text.Text
 
@@ -61,7 +64,10 @@ class KnappingStationScreen(
 
         // Draw the background texture using the GUI render pipeline
         context.drawTexture(
+            //? if >=1.21.6 {
             RenderPipelines.GUI_TEXTURED, // Use the GUI texture pipeline for proper rendering
+            //?} else {
+            /*RenderLayer::getGuiTextured,*///?}
             TEXTURE,                      // The texture to draw
             x, y,                         // Screen position to draw at
             0f, 0f,                       // Starting UV coordinates in the texture

--- a/src/main/java/com/toolsandtaverns/paleolithicera/mixin/BlockBreakingPreventionMixin.java
+++ b/src/main/java/com/toolsandtaverns/paleolithicera/mixin/BlockBreakingPreventionMixin.java
@@ -50,7 +50,10 @@ public abstract class BlockBreakingPreventionMixin {
         if (action != PlayerActionC2SPacket.Action.START_DESTROY_BLOCK) return;
         if(player.isCreative()) return;
 
+        //? if >=1.21.6 {
         ServerWorld world = player.getWorld();
+        //?} else {
+        /*ServerWorld world = (ServerWorld) player.getWorld();*///?}
         BlockState state = player.getWorld().getBlockState(pos);
 
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/CrudeCampFireBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/CrudeCampFireBlock.kt
@@ -41,6 +41,20 @@ class CrudeCampFireBlock(settings: Settings) : CampfireBlock(false, 1, settings)
         return CrudeCampfireBlockEntity(pos, state)
     }
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? CrudeCampfireBlockEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun <T : BlockEntity?> getTicker(
         world: World,
         state: BlockState,

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/EdiblePlantBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/EdiblePlantBlock.kt
@@ -3,6 +3,7 @@ package com.toolsandtaverns.paleolithicera.block
 import net.minecraft.block.BlockState
 import net.minecraft.block.SweetBerryBushBlock
 import net.minecraft.entity.Entity
+//? if >1.21.4
 import net.minecraft.entity.EntityCollisionHandler
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.Item
@@ -35,7 +36,10 @@ class EdiblePlantBlock(settings: Settings, private val edibleItem: Item) : Sweet
         if (isMature) {
             if (!world.isClient) {
                 val dropStack = ItemStack(edibleItem, 1)
+                //? if >1.21.4 {
                 dropStack.onCraftByPlayer(player, 1)
+                //?} else {
+                /*dropStack.onCraftByPlayer(world, player, 1)*///?}
                 if (!player.giveItemStack(dropStack)) {
                     player.dropItem(dropStack, false)
                 }
@@ -51,6 +55,7 @@ class EdiblePlantBlock(settings: Settings, private val edibleItem: Item) : Sweet
         world: World,
         pos: BlockPos,
         entity: Entity,
+        //? if >1.21.4
         handler: EntityCollisionHandler
     ) {
         // We do not want to damage or slow player

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/EffigyOfProtectionBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/EffigyOfProtectionBlock.kt
@@ -102,6 +102,20 @@ class EffigyOfProtectionBlock(settings: Settings) : BlockWithEntity(settings) {
         return EffigyOfProtectionEntity(pos, state)
     }
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? EffigyOfProtectionEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun getPlacementState(ctx: ItemPlacementContext): BlockState? {
         val pos = ctx.blockPos
         val world = ctx.world

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/FoodDryerBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/FoodDryerBlock.kt
@@ -65,6 +65,20 @@ class FoodDryerBlock(settings: Settings) : BlockWithEntity(settings) {
         return FoodDryerBlockEntity(pos, state)
     }
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? FoodDryerBlockEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun createScreenHandlerFactory(
         state: BlockState,
         world: World,

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/GroundStorageBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/GroundStorageBlock.kt
@@ -28,6 +28,20 @@ class GroundStorageBlock(settings: Settings) : BlockWithEntity(settings) {
     override fun createBlockEntity(pos: BlockPos, state: BlockState): BlockEntity =
         GroundStorageBlockEntity(pos, state)
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? GroundStorageBlockEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun getRenderType(state: BlockState): BlockRenderType = BlockRenderType.MODEL
 
     override fun createScreenHandlerFactory(

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/HideDryerBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/HideDryerBlock.kt
@@ -38,6 +38,20 @@ class HideDryerBlock(settings: Settings) : BlockWithEntity(settings) {
         return HideDryerBlockEntity(pos, state)
     }
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? HideDryerBlockEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun getRenderType(state: BlockState): BlockRenderType {
         return BlockRenderType.MODEL
     }

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/KnappingStationBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/KnappingStationBlock.kt
@@ -23,6 +23,20 @@ class KnappingStationBlock(settings: Settings) : BlockWithEntity(settings) {
     override fun createBlockEntity(pos: BlockPos, state: BlockState): BlockEntity =
         KnappingStationBlockEntity(pos, state)
 
+    //? if <=1.21.4 {
+    /*override fun onStateReplaced(
+        state: BlockState,
+        world: World,
+        pos: BlockPos,
+        newState: BlockState,
+        moved: Boolean
+    ) {
+        if (!state.isOf(newState.block)) {
+            (world.getBlockEntity(pos) as? KnappingStationBlockEntity)?.dropItems(world, pos)
+        }
+        super.onStateReplaced(state, world, pos, newState, moved)
+    }*///?}
+
     override fun createScreenHandlerFactory(
         state: BlockState,
         world: World,

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/WillowLeafVinesBlock.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/block/WillowLeafVinesBlock.kt
@@ -37,6 +37,7 @@ class WillowLeafVinesBlock(settings: Settings) : Block(settings) {
     }
 
     private fun createShapeFunction(): Function<BlockState, VoxelShape> {
+        //? if >1.21.4 {
         val map = VoxelShapes.createFacingShapeMap(createCuboidZShape(16.0, 0.0, 1.0))
         return this.createShapeFunction { state: BlockState ->
             var voxelShape = VoxelShapes.empty()
@@ -50,6 +51,24 @@ class WillowLeafVinesBlock(settings: Settings) : Block(settings) {
             }
             if (voxelShape.isEmpty) VoxelShapes.fullCube() else voxelShape
         }
+        //?} else {
+        /*val faceShapes = mutableMapOf<Direction, VoxelShape>()
+        val thickness = 1.0 / 16.0
+        faceShapes[Direction.NORTH] = VoxelShapes.cuboid(0.0, 0.0, 0.0, 1.0, 1.0, thickness)
+        faceShapes[Direction.SOUTH] = VoxelShapes.cuboid(0.0, 0.0, 1.0 - thickness, 1.0, 1.0, 1.0)
+        faceShapes[Direction.WEST] = VoxelShapes.cuboid(0.0, 0.0, 0.0, thickness, 1.0, 1.0)
+        faceShapes[Direction.EAST] = VoxelShapes.cuboid(1.0 - thickness, 0.0, 0.0, 1.0, 1.0, 1.0)
+        faceShapes[Direction.UP] = VoxelShapes.cuboid(0.0, 1.0 - thickness, 0.0, 1.0, 1.0, 1.0)
+
+        return Function { state: BlockState ->
+            var shape = VoxelShapes.empty()
+            for ((direction, property) in FACING_PROPERTIES) {
+                if (state.get(property)) {
+                    faceShapes[direction]?.let { shape = VoxelShapes.union(shape, it) }
+                }
+            }
+            if (shape.isEmpty) VoxelShapes.fullCube() else shape
+        }*///?}
     }
 
     override fun getOutlineShape(

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModBlockTagProvider.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModBlockTagProvider.kt
@@ -4,12 +4,14 @@ import com.toolsandtaverns.paleolithicera.registry.ModBlocks
 import com.toolsandtaverns.paleolithicera.registry.ModTags
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
+import net.minecraft.block.Block
 import net.minecraft.block.Blocks
 import net.minecraft.registry.RegistryKey
 import net.minecraft.registry.RegistryKeys
 import net.minecraft.registry.RegistryWrapper
 import net.minecraft.registry.tag.BlockTags
 import net.minecraft.registry.tag.ItemTags
+import net.minecraft.registry.tag.TagKey
 import net.minecraft.util.Identifier
 import java.util.concurrent.CompletableFuture
 
@@ -41,6 +43,12 @@ class ModBlockTagProvider(
     registriesFuture: CompletableFuture<RegistryWrapper.WrapperLookup>
 ) : FabricTagProvider.BlockTagProvider(output, registriesFuture) {
 
+    private fun tagBuilder(tag: TagKey<Block>) =
+        //? if >=1.21.6 {
+        valueLookupBuilder(tag)
+        //?} else {
+        /*getOrCreateTagBuilder(tag)*///?}
+
     /**
      * Configures all block tags for the Paleolithic Era mod.
      *
@@ -56,35 +64,35 @@ class ModBlockTagProvider(
      * @param wrapperLookup Registry wrapper lookup for accessing block registries
      */
     override fun configure(wrapperLookup: RegistryWrapper.WrapperLookup) {
-        valueLookupBuilder(BlockTags.LOGS_THAT_BURN)
+        tagBuilder(BlockTags.LOGS_THAT_BURN)
             .add(ModBlocks.WILLOW_LOG)
             .add(ModBlocks.STRIPPED_WILLOW_LOG)
 
-        valueLookupBuilder(BlockTags.LOGS)
+        tagBuilder(BlockTags.LOGS)
             .add(ModBlocks.WILLOW_LOG)
             .add(ModBlocks.STRIPPED_WILLOW_LOG)
 
         // All log types are added to the unbreakable tag, as harvesting trees without tools
         // would have been impossible for Paleolithic humans. This creates an important
         // progression gate where players must craft primitive axes before accessing wood in quantity.
-        valueLookupBuilder(ModTags.Blocks.UNBREAKABLE_TAG)
+        tagBuilder(ModTags.Blocks.UNBREAKABLE_TAG)
             .addOptionalTag(BlockTags.LOGS)
 
-        valueLookupBuilder(ModTags.Blocks.REQUIRES_SHOVEL)
+        tagBuilder(ModTags.Blocks.REQUIRES_SHOVEL)
             .addOptionalTag(BlockTags.DIRT)
             .add(ModBlocks.GROUND_STORAGE)
 
 
-        valueLookupBuilder(BlockTags.SWORD_EFFICIENT)
+        tagBuilder(BlockTags.SWORD_EFFICIENT)
             .add(ModBlocks.WILLOW_LEAF_VINES)
 
         // Tool tags: axe-mineable for new wood/bone-like blocks used in the effigy
-        valueLookupBuilder(BlockTags.AXE_MINEABLE)
+        tagBuilder(BlockTags.AXE_MINEABLE)
             .add(ModBlocks.BUNDLE_OF_STICKS)
             .add(ModBlocks.EFFIGY_OF_PROTECTION)
 
         // Shovel mineable for ground storage (dirt-based block)
-        valueLookupBuilder(BlockTags.SHOVEL_MINEABLE)
+        tagBuilder(BlockTags.SHOVEL_MINEABLE)
             .add(ModBlocks.GROUND_STORAGE)
 
     }

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModEntityTypeTagProvider.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModEntityTypeTagProvider.kt
@@ -8,6 +8,7 @@ import net.minecraft.entity.EntityType
 import net.minecraft.registry.RegistryKey
 import net.minecraft.registry.RegistryKeys
 import net.minecraft.registry.RegistryWrapper
+import net.minecraft.registry.tag.TagKey
 import net.minecraft.util.Identifier
 import java.util.concurrent.CompletableFuture
 
@@ -37,6 +38,12 @@ class ModEntityTypeTagProvider(
     registries: CompletableFuture<RegistryWrapper.WrapperLookup>
 ) : FabricTagProvider.EntityTypeTagProvider(output, registries) {
 
+    private fun tagBuilder(tag: TagKey<EntityType<*>>) =
+        //? if >=1.21.6 {
+        builder(tag)
+        //?} else {
+        /*getOrCreateTagBuilder(tag)*///?}
+
     /**
      * Configures the entity type tags for the Paleolithic Era mod.
      *
@@ -48,19 +55,25 @@ class ModEntityTypeTagProvider(
      * @param lookup Registry wrapper lookup for accessing entity type registries
      */
     override fun configure(lookup: RegistryWrapper.WrapperLookup) {
-        val huntableBuilder = builder(ModTags.Entity.HUNTABLE_TAG)
-        val aggressiveBuilder = builder(ModTags.Entity.AGGRESSIVE)
+        val huntableBuilder = tagBuilder(ModTags.Entity.HUNTABLE_TAG)
+        val aggressiveBuilder = tagBuilder(ModTags.Entity.AGGRESSIVE)
 
         huntableAnimals.forEach { entityType ->
+            //? if >=1.21.6 {
             val id: Identifier = EntityType.getId(entityType)
             val key: RegistryKey<EntityType<*>> = RegistryKey.of(RegistryKeys.ENTITY_TYPE, id)
             huntableBuilder.add(key)
+            //?} else {
+            /*huntableBuilder.add(entityType)*///?}
         }
 
         aggressiveAnimals.forEach { entityType ->
+            //? if >=1.21.6 {
             val id: Identifier = EntityType.getId(entityType)
             val key: RegistryKey<EntityType<*>> = RegistryKey.of(RegistryKeys.ENTITY_TYPE, id)
             aggressiveBuilder.add(key)
+            //?} else {
+            /*aggressiveBuilder.add(entityType)*///?}
         }
     }
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModItemTagProvider.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/datagen/tag/ModItemTagProvider.kt
@@ -6,9 +6,11 @@ import com.toolsandtaverns.paleolithicera.registry.ModTags
 import com.toolsandtaverns.paleolithicera.registry.custom.EdiblePlants
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
+import net.minecraft.item.Item
 import net.minecraft.item.Items
 import net.minecraft.registry.RegistryWrapper
 import net.minecraft.registry.tag.ItemTags
+import net.minecraft.registry.tag.TagKey
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -34,6 +36,12 @@ import java.util.concurrent.CompletableFuture
 class ModItemTagProvider(output: FabricDataOutput, val registries: CompletableFuture<RegistryWrapper.WrapperLookup>) :
     FabricTagProvider.ItemTagProvider(output, registries) {
 
+    private fun tagBuilder(tag: TagKey<Item>) =
+        //? if >=1.21.6 {
+        valueLookupBuilder(tag)
+        //?} else {
+        /*getOrCreateTagBuilder(tag)*///?}
+
     /**
      * Configures all item tags for the Paleolithic Era mod.
      *
@@ -46,40 +54,40 @@ class ModItemTagProvider(output: FabricDataOutput, val registries: CompletableFu
     override fun configure(arg: RegistryWrapper.WrapperLookup) {
         // Bone-based materials represent one of the earliest readily available hard materials
         // used by Paleolithic humans for tools and weapons
-        valueLookupBuilder(ModTags.Items.BONE_TOOL_MATERIALS)
+        tagBuilder(ModTags.Items.BONE_TOOL_MATERIALS)
             .add(Items.BONE)
             .add(ModItems.BONE_KNIFE)
             .add(ModItems.BONE_SPEAR)
 
         // Flint tools represent a technological advancement over bone, offering
         // sharper edges and more durable cutting surfaces
-        valueLookupBuilder(ModTags.Items.FLINT_TOOL_MATERIALS)
+        tagBuilder(ModTags.Items.FLINT_TOOL_MATERIALS)
             .add(ModItems.FLINT_KNIFE)
             .add(Items.FLINT)
 
         // Defines materials that can repair hide-based armor, simulating how
         // Paleolithic humans would patch damaged clothing with additional hide pieces
-        valueLookupBuilder(ModTags.Items.REPAIRS_HIDE_ARMOR)
+        tagBuilder(ModTags.Items.REPAIRS_HIDE_ARMOR)
             .add(ModItems.DRY_HIDE)
             .add(ModItems.PATCHED_HIDE)
 
         // Spears were one of the most important hunting and defense tools in the Paleolithic era,
         // with variations made from different available materials
-        valueLookupBuilder(ModTags.Items.SPEARS)
+        tagBuilder(ModTags.Items.SPEARS)
             .add(ModItems.WOODEN_SPEAR)
             .add(ModItems.BONE_SPEAR)
 
         // Knives were versatile tools used for everything from food preparation
         // to hide processing and crafting other tools
-        valueLookupBuilder(ModTags.Items.KNIFE)
+        tagBuilder(ModTags.Items.KNIFE)
             .add(ModItems.FLINT_BIFACE)
             .add(ModItems.BONE_KNIFE)
             .add(ModItems.FLINT_KNIFE)
 
-        valueLookupBuilder(ItemTags.PLANKS)
+        tagBuilder(ItemTags.PLANKS)
             .add(ModBlocks.WILLOW_PLANKS.asItem())
 
-        valueLookupBuilder(ModTags.Items.IBEX_FOOD)
+        tagBuilder(ModTags.Items.IBEX_FOOD)
             .add(ModItems.getPlantItem(EdiblePlants.YARROW))
             .add(Items.WHEAT)
     }

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/CrudeCampfireBlockEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/CrudeCampfireBlockEntity.kt
@@ -1,11 +1,14 @@
 package com.toolsandtaverns.paleolithicera.entity
 
-import com.toolsandtaverns.paleolithicera.PaleolithicEra.LOGGER
 import com.toolsandtaverns.paleolithicera.registry.ModEntityType
+//? if >=1.21.6 {
+import com.toolsandtaverns.paleolithicera.PaleolithicEra.LOGGER
+//?}
 import net.minecraft.block.BlockState
 import net.minecraft.block.CampfireBlock
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.component.ComponentMap
+//? if >1.21.4
 import net.minecraft.component.ComponentsAccess
 import net.minecraft.component.DataComponentTypes
 import net.minecraft.component.type.ContainerComponent
@@ -22,11 +25,15 @@ import net.minecraft.recipe.ServerRecipeManager.MatchGetter
 import net.minecraft.recipe.input.SingleStackRecipeInput
 import net.minecraft.registry.RegistryWrapper.WrapperLookup
 import net.minecraft.server.world.ServerWorld
+//? if >=1.21.6 {
 import net.minecraft.storage.NbtWriteView
 import net.minecraft.storage.ReadView
 import net.minecraft.storage.WriteView
+//?}
 import net.minecraft.util.Clearable
+//? if >=1.21.6 {
 import net.minecraft.util.ErrorReporter
+//?}
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.collection.DefaultedList
 import net.minecraft.util.math.BlockPos
@@ -100,6 +107,7 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      *
      * @param view The data source to read from
      */
+    //? if >=1.21.6 {
     override fun readData(view: ReadView) {
         super.readData(view)
         this.itemsBeingCooked.clear()
@@ -124,6 +132,44 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
         }) { Arrays.fill(this.cookingTotalTimes, 0) }
         burnTicksRemaining = view.getInt("BurnTicksRemaining", 0)
     }
+    //?} else if >1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: WrapperLookup) {
+        super.readNbt(nbt, registries)
+        itemsBeingCooked.clear()
+        Inventories.readNbt(nbt, itemsBeingCooked, registries)
+        val times = nbt.getIntArray("CookingTimes").orElse(IntArray(0))
+        if (times.isNotEmpty()) {
+            System.arraycopy(times, 0, cookingTimes, 0, min(cookingTimes.size, times.size))
+        } else {
+            Arrays.fill(cookingTimes, 0)
+        }
+        val totalTimes = nbt.getIntArray("CookingTotalTimes").orElse(IntArray(0))
+        if (totalTimes.isNotEmpty()) {
+            System.arraycopy(totalTimes, 0, cookingTotalTimes, 0, min(cookingTotalTimes.size, totalTimes.size))
+        } else {
+            Arrays.fill(cookingTotalTimes, 0)
+        }
+        burnTicksRemaining = nbt.getInt("BurnTicksRemaining").orElse(0)
+    }*///?}
+    //? if <=1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: WrapperLookup) {
+        super.readNbt(nbt, registries)
+        itemsBeingCooked.clear()
+        Inventories.readNbt(nbt, itemsBeingCooked, registries)
+        val times = nbt.getIntArray("CookingTimes")
+        if (times.isNotEmpty()) {
+            System.arraycopy(times, 0, cookingTimes, 0, min(cookingTimes.size, times.size))
+        } else {
+            Arrays.fill(cookingTimes, 0)
+        }
+        val totalTimes = nbt.getIntArray("CookingTotalTimes")
+        if (totalTimes.isNotEmpty()) {
+            System.arraycopy(totalTimes, 0, cookingTotalTimes, 0, min(cookingTotalTimes.size, totalTimes.size))
+        } else {
+            Arrays.fill(cookingTotalTimes, 0)
+        }
+        burnTicksRemaining = nbt.getInt("BurnTicksRemaining")
+    }*///?}
 
     /**
      * Writes the entity's data to NBT or component storage.
@@ -140,6 +186,7 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      *
      * @param view The data destination to write to
      */
+    //? if >=1.21.6 {
     override fun writeData(view: WriteView) {
         super.writeData(view)
         Inventories.writeData(view, this.itemsBeingCooked, true)
@@ -147,6 +194,14 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
         view.putIntArray("CookingTotalTimes", this.cookingTotalTimes)
         view.putInt("BurnTicksRemaining", burnTicksRemaining)
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, itemsBeingCooked, true, registries)
+        nbt.putIntArray("CookingTimes", cookingTimes)
+        nbt.putIntArray("CookingTotalTimes", cookingTotalTimes)
+        nbt.putInt("BurnTicksRemaining", burnTicksRemaining)
+    }*///?}
 
     /**
      * Creates a packet to send this block entity's data to clients.
@@ -171,6 +226,7 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      * @param registries Registry wrapper for data serialization
      * @return NBT compound containing initial chunk data
      */
+    //? if >=1.21.6 {
     override fun toInitialChunkDataNbt(registries: WrapperLookup): NbtCompound? {
         ErrorReporter.Logging(this.reporterContext, LOGGER).use { logging ->
             val nbtWriteView = NbtWriteView.create(logging, registries)
@@ -178,6 +234,8 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
             return nbtWriteView.nbt
         }
     }
+    //?} else {
+    /*override fun toInitialChunkDataNbt(registries: WrapperLookup): NbtCompound = createNbt(registries)*///?}
 
     /**
      * Attempts to add an item to the campfire for cooking.
@@ -260,11 +318,14 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      * @param pos The position of the block
      * @param oldState The previous blockstate
      */
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState?) {
-        if (this.world != null) {
-            ItemScatterer.spawn(this.world, pos, this.itemsBeingCooked)
-        }
+    fun dropItems(world: World, pos: BlockPos) {
+        ItemScatterer.spawn(world, pos, itemsBeingCooked)
     }
+
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState?) {
+        world?.let { dropItems(it, pos) }
+    }//?}
 
     /**
      * Reads component data from the component system.
@@ -275,6 +336,7 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      *
      * @param components The components access object containing data
      */
+    //? if >1.21.4 {
     override fun readComponents(components: ComponentsAccess) {
         super.readComponents(components)
         (components.getOrDefault(
@@ -310,10 +372,12 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
      *
      * @param view The write view to modify
      */
+    //? if >=1.21.6 {
     @Deprecated("Deprecated in Java")
     override fun removeFromCopiedStackData(view: WriteView) {
         view.remove("Items")
-    }
+    }//?}
+    //?}
 
     /**
      * Starts the burn timer for the crude campfire.
@@ -496,7 +560,10 @@ class CrudeCampfireBlockEntity(pos: BlockPos, state: BlockState?) :
                         .toFloat() * fixed).toDouble()
 
                     (0..3).forEach { k ->
+                        //? if >1.21.4 {
                         world.addParticleClient(ParticleTypes.SMOKE, d, e, g, 0.0, 5.0E-4, 0.0)
+                        //?} else {
+                        /*world.addParticle(ParticleTypes.SMOKE, d, e, g, 0.0, 5.0E-4, 0.0)*///?}
                     }
                 }
             }

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/EffigyOfProtectionEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/EffigyOfProtectionEntity.kt
@@ -10,12 +10,16 @@ import net.minecraft.inventory.Inventories
 import net.minecraft.inventory.SimpleInventory
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
+import net.minecraft.nbt.NbtCompound
 import net.minecraft.particle.ParticleTypes
+import net.minecraft.registry.RegistryWrapper
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.text.Text
 import net.minecraft.util.ItemScatterer
+//? if >=1.21.6 {
 import net.minecraft.storage.ReadView
 import net.minecraft.storage.WriteView
+//?}
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
@@ -224,22 +228,47 @@ class EffigyOfProtectionEntity(pos: BlockPos, state: BlockState) :
         return String.format("%02d:%02d", m, s)
     }
 
+    //? if >=1.21.6 {
     override fun readData(view: ReadView) {
         super.readData(view)
         Inventories.readData(view, inventory.heldStacks)
         activeTicks = view.getInt("ActiveTicks", 0)
     }
+    //?} else if >1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        activeTicks = nbt.getInt("ActiveTicks").orElse(0)
+    }*///?}
+    //? if <=1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        activeTicks = nbt.getInt("ActiveTicks")
+    }*///?}
 
+    //? if >=1.21.6 {
     override fun writeData(view: WriteView) {
         super.writeData(view)
         Inventories.writeData(view, inventory.heldStacks)
         view.putInt("ActiveTicks", activeTicks)
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, inventory.heldStacks, registries)
+        nbt.putInt("ActiveTicks", activeTicks)
+    }*///?}
 
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
-        ItemScatterer.spawn(world as World, pos, inventory)
-        super.onBlockReplaced(pos, oldState)
+    fun dropItems(world: World, pos: BlockPos) {
+        ItemScatterer.spawn(world, pos, inventory)
     }
+
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+        world?.let { dropItems(it, pos) }
+        super.onBlockReplaced(pos, oldState)
+    }//?}
 
     // Helper extension
     private fun Vec3d.isInRadius(center: Vec3d, r: Double): Boolean = this.squaredDistanceTo(center) <= r * r

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/FoodDryerBlockEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/FoodDryerBlockEntity.kt
@@ -24,8 +24,10 @@ import net.minecraft.screen.PropertyDelegate
 import net.minecraft.screen.ScreenHandler
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
+//? if >=1.21.6 {
 import net.minecraft.storage.ReadView
 import net.minecraft.storage.WriteView
+//?}
 import net.minecraft.text.Text
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.math.BlockPos
@@ -255,10 +257,15 @@ class FoodDryerBlockEntity(
     }
 
 
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+    fun dropItems(world: World, pos: BlockPos) {
         ItemScatterer.spawn(world, pos, inventory)
-        super.onBlockReplaced(pos, oldState)
     }
+
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+        world?.let { dropItems(it, pos) }
+        super.onBlockReplaced(pos, oldState)
+    }//?}
 
     override fun getScreenOpeningData(player: ServerPlayerEntity): BlockPos {
         return this.pos
@@ -291,6 +298,7 @@ class FoodDryerBlockEntity(
      *
      * @param view The data source to read from
      */
+    //? if >=1.21.6 {
     override fun readData(view: net.minecraft.storage.ReadView) {
         super.readData(view)
         Inventories.readData(view, inventory.heldStacks)
@@ -300,6 +308,22 @@ class FoodDryerBlockEntity(
             slotProgress[slot] = view.getFloat("SlotProgress$slot", 0.0f)
         }
     }
+    //?} else if >1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        for (slot in 0 until SLOT_COUNT) {
+            slotProgress[slot] = nbt.getFloat("SlotProgress$slot").orElse(0.0f)
+        }
+    }*///?}
+    //? if <=1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        for (slot in 0 until SLOT_COUNT) {
+            slotProgress[slot] = nbt.getFloat("SlotProgress$slot")
+        }
+    }*///?}
 
     /**
      * Writes the entity's data to NBT or component storage.
@@ -310,6 +334,7 @@ class FoodDryerBlockEntity(
      *
      * @param view The data destination to write to
      */
+    //? if >=1.21.6 {
     override fun writeData(view: net.minecraft.storage.WriteView) {
         super.writeData(view)
         Inventories.writeData(view, inventory.heldStacks)
@@ -319,6 +344,14 @@ class FoodDryerBlockEntity(
             view.putFloat("SlotProgress$slot", slotProgress[slot])
         }
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, inventory.heldStacks, registries)
+        for (slot in 0 until SLOT_COUNT) {
+            nbt.putFloat("SlotProgress$slot", slotProgress[slot])
+        }
+    }*///?}
 
 
     /**

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/GroundStorageBlockEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/GroundStorageBlockEntity.kt
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.inventory.Inventories
 import net.minecraft.inventory.SimpleInventory
 import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NbtCompound
 import net.minecraft.network.listener.ClientPlayPacketListener
 import net.minecraft.network.packet.Packet
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket
@@ -20,6 +21,7 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.math.BlockPos
+import net.minecraft.world.World
 
 /**
  * Block entity for Ground Storage. Stores up to 8 stackable items.
@@ -52,20 +54,37 @@ class GroundStorageBlockEntity(pos: BlockPos, state: BlockState) :
         player: PlayerEntity
     ): ScreenHandler = GroundStorageScreenHandler(syncId, playerInventory, this)
 
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+    fun dropItems(world: World, pos: BlockPos) {
         ItemScatterer.spawn(world, pos, inventory)
-        super.onBlockReplaced(pos, oldState)
     }
 
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+        world?.let { dropItems(it, pos) }
+        super.onBlockReplaced(pos, oldState)
+    }//?}
+
+    //? if >=1.21.6 {
     override fun readData(view: net.minecraft.storage.ReadView) {
         super.readData(view)
         Inventories.readData(view, inventory.heldStacks)
     }
+    //?} else {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+    }*///?}
 
+    //? if >=1.21.6 {
     override fun writeData(view: net.minecraft.storage.WriteView) {
         super.writeData(view)
         Inventories.writeData(view, inventory.heldStacks)
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, inventory.heldStacks, registries)
+    }*///?}
 
     override fun toUpdatePacket(): Packet<ClientPlayPacketListener> =
         BlockEntityUpdateS2CPacket.create(this)

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/HideDryerBlockEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/HideDryerBlockEntity.kt
@@ -19,8 +19,10 @@ import net.minecraft.registry.RegistryWrapper
 import net.minecraft.screen.PropertyDelegate
 import net.minecraft.screen.ScreenHandler
 import net.minecraft.server.network.ServerPlayerEntity
+//? if >=1.21.6 {
 import net.minecraft.storage.ReadView
 import net.minecraft.storage.WriteView
+//?}
 import net.minecraft.text.Text
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.math.BlockPos
@@ -160,10 +162,15 @@ class HideDryerBlockEntity(
      * @param pos The position of the block
      * @param oldState The previous blockstate
      */
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+    fun dropItems(world: World, pos: BlockPos) {
         ItemScatterer.spawn(world, pos, inventory)
-        super.onBlockReplaced(pos, oldState)
     }
+
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+        world?.let { dropItems(it, pos) }
+        super.onBlockReplaced(pos, oldState)
+    }//?}
 
     /**
      * Provides data needed when opening the hide dryer screen.
@@ -266,6 +273,7 @@ class HideDryerBlockEntity(
      *
      * @param view The data source to read from
      */
+    //? if >=1.21.6 {
     override fun readData(view: ReadView) {
         super.readData(view)
         Inventories.readData(view, inventory.heldStacks)
@@ -273,6 +281,18 @@ class HideDryerBlockEntity(
         // Read the drying progress
         progress = view.getFloat("DryingProgress", 0.0f)
     }
+    //?} else if >1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        progress = nbt.getFloat("DryingProgress").orElse(0.0f)
+    }*///?}
+    //? if <=1.21.4 {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.readNbt(nbt, registries)
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        progress = nbt.getFloat("DryingProgress")
+    }*///?}
 
     /**
      * Writes the entity's data to NBT or component storage.
@@ -283,6 +303,7 @@ class HideDryerBlockEntity(
      *
      * @param view The data destination to write to
      */
+    //? if >=1.21.6 {
     override fun writeData(view: WriteView) {
         super.writeData(view)
         Inventories.writeData(view, inventory.heldStacks)
@@ -290,5 +311,11 @@ class HideDryerBlockEntity(
         // Write the drying progress
         view.putFloat("DryingProgress", progress)
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, inventory.heldStacks, registries)
+        nbt.putFloat("DryingProgress", progress)
+    }*///?}
 
 }

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/KnappingStationBlockEntity.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/entity/KnappingStationBlockEntity.kt
@@ -22,8 +22,10 @@ import net.minecraft.registry.RegistryWrapper
 import net.minecraft.screen.ScreenHandler
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
+//? if >=1.21.6 {
 import net.minecraft.storage.ReadView
 import net.minecraft.storage.WriteView
+//?}
 import net.minecraft.text.Text
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.math.BlockPos
@@ -93,10 +95,16 @@ class KnappingStationBlockEntity(pos: BlockPos, state: BlockState) :
      *
      * @param view The data source to read from
      */
+    //? if >=1.21.6 {
     override fun readData(view: ReadView) {
         Inventories.readData(view, inventory.heldStacks)
         super.readData(view)
     }
+    //?} else {
+    /*override fun readNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        Inventories.readNbt(nbt, inventory.heldStacks, registries)
+        super.readNbt(nbt, registries)
+    }*///?}
 
     /**
      * Writes the entity's data to NBT or component storage.
@@ -108,10 +116,16 @@ class KnappingStationBlockEntity(pos: BlockPos, state: BlockState) :
      *
      * @param view The data destination to write to
      */
+    //? if >=1.21.6 {
     override fun writeData(view: WriteView) {
         super.writeData(view)
         Inventories.writeData(view, inventory.heldStacks)
     }
+    //?} else {
+    /*override fun writeNbt(nbt: NbtCompound, registries: RegistryWrapper.WrapperLookup) {
+        super.writeNbt(nbt, registries)
+        Inventories.writeNbt(nbt, inventory.heldStacks, registries)
+    }*///?}
 
     /**
      * Provides access to the knapping station's inventory.
@@ -169,10 +183,15 @@ class KnappingStationBlockEntity(pos: BlockPos, state: BlockState) :
      * @param pos The position of the block
      * @param oldState The previous blockstate
      */
-    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+    fun dropItems(world: World, pos: BlockPos) {
         ItemScatterer.spawn(world, pos, inventory)
-        super.onBlockReplaced(pos, oldState)
     }
+
+    //? if >1.21.4 {
+    override fun onBlockReplaced(pos: BlockPos, oldState: BlockState) {
+        world?.let { dropItems(it, pos) }
+        super.onBlockReplaced(pos, oldState)
+    }//?}
 
 
     /**

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/FireDrillItem.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/FireDrillItem.kt
@@ -102,7 +102,10 @@ class FireDrillItem(settings: Settings) : Item(settings) {
                 }
 
                 // Damage the fire drill item by 1 durability point
+                //? if >=1.21.6 {
                 stack.damage(1, user, user.activeHand)
+                //?} else {
+                /*stack.damage(1, user, LivingEntity.getSlotForHand(user.activeHand))*///?}
             }
         }
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/HarpoonItem.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/HarpoonItem.kt
@@ -2,6 +2,7 @@ package com.toolsandtaverns.paleolithicera.item
 
 import com.toolsandtaverns.paleolithicera.network.OpenHarpoonGuiPacket
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
+//? if >1.21.4
 import net.minecraft.component.type.TooltipDisplayComponent
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.fluid.Fluids
@@ -18,6 +19,7 @@ import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.RaycastContext
 import net.minecraft.world.World
+//? if >1.21.4
 import java.util.function.Consumer
 
 /**
@@ -63,6 +65,7 @@ open class HarpoonItem(settings: Settings) : Item(settings) {
     }
 
     @Deprecated("Overrides a deprecated method", level = DeprecationLevel.HIDDEN)
+    //? if >1.21.4 {
     override fun appendTooltip(
         stack: ItemStack,
         context: TooltipContext,
@@ -78,5 +81,20 @@ open class HarpoonItem(settings: Settings) : Item(settings) {
             )
         }
     }
+    //?} else {
+    /*override fun appendTooltip(
+        stack: ItemStack,
+        context: TooltipContext,
+        tooltip: MutableList<Text>,
+        type: TooltipType
+    ) {
+        if (type.isAdvanced && stack.isDamaged) {
+            val durability = stack.maxDamage - stack.damage
+            tooltip.add(
+                Text.translatable("item.durability", durability, stack.maxDamage)
+                    .formatted(Formatting.DARK_GRAY)
+            )
+        }
+    }*///?}
 }
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/KnifeItem.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/KnifeItem.kt
@@ -45,7 +45,12 @@ class KnifeItem(
     settings: Settings,
     attackDamage: Float = 0.5f,
     attackSpeed: Float = -2.2f,
-) : Item(settings.tool(material, BlockTags.WOOL, attackDamage, attackSpeed, 0.0F)) {
+) : Item(
+    //? if >1.21.4 {
+    settings.tool(material, BlockTags.WOOL, attackDamage, attackSpeed, 0.0F)
+    //?} else {
+    /*material.applyToolSettings(settings, BlockTags.WOOL, attackDamage, attackSpeed)*///?}
+) {
 
     /**
      * Handles the behavior when the knife is used on a block, primarily for stripping logs.
@@ -142,9 +147,14 @@ class KnifeItem(
      * @return true if the stripping attempt should be canceled, false otherwise
      */
     private fun shouldCancelStripAttempt(context: ItemUsageContext): Boolean {
+        //? if >1.21.4 {
         val playerEntity = context.player ?: return false
         return context.hand == Hand.MAIN_HAND && playerEntity.offHandStack
             .contains(DataComponentTypes.BLOCKS_ATTACKS) && !playerEntity.shouldCancelInteraction()
+        //?} else {
+        /*val player = context.player ?: return false
+        return context.hand == Hand.MAIN_HAND && player.offHandStack.isOf(Items.SHIELD) &&
+            player.isUsingItem && !player.shouldCancelInteraction()*///?}
     }
 
     /**

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/SpearItem.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/SpearItem.kt
@@ -57,7 +57,10 @@ class SpearItem(settings: Settings, private val projectileCreator: ProjectileEnt
         }
 
         fun createToolComponent(material: ToolMaterial): ToolComponent {
+            //? if >1.21.4 {
             return ToolComponent(mutableListOf(), material.speed, 2, false)
+            //?} else {
+            /*return ToolComponent(mutableListOf(), material.speed, 2)*///?}
         }
     }
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/WaterSackItem.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/item/WaterSackItem.kt
@@ -37,7 +37,10 @@ class WaterSackItem(settings: Settings) : Item(settings) {
             val areaEffectCloudEntity = list[0] as AreaEffectCloudEntity
             areaEffectCloudEntity.radius = areaEffectCloudEntity.radius - 0.5f
             world.playSound(
+                //? if >1.21.4 {
                 null as Entity?,
+                //?} else {
+                /*null as PlayerEntity?,*///?}
                 user.x,
                 user.y,
                 user.z,
@@ -60,7 +63,10 @@ class WaterSackItem(settings: Settings) : Item(settings) {
             } else {
                 if (blockHitResult.type == HitResult.Type.BLOCK) {
                     val blockPos = blockHitResult.blockPos
+                    //? if >1.21.4 {
                     if (!world.canEntityModifyAt(user, blockPos)) {
+                    //?} else {
+                    /*if (!world.canPlayerModifyAt(user, blockPos)) {*///?}
                         return ActionResult.PASS
                     }
 

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/network/OpenHarpoonGuiPacket.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/network/OpenHarpoonGuiPacket.kt
@@ -99,7 +99,10 @@ object OpenHarpoonGuiPacket {
         )
 
         // Damage the harpoon and handle potential breakage
+        //? if >=1.21.6 {
         stack.damage(1, player, attempt.hand)
+        //?} else {
+        /*stack.damage(1, player, slot)*///?}
         if (stack.isEmpty) {
             // Notify the client that the item broke for proper visual/sound effects
             player.sendEquipmentBreakStatus(item, slot)

--- a/src/main/kotlin/com/toolsandtaverns/paleolithicera/registry/ModItems.kt
+++ b/src/main/kotlin/com/toolsandtaverns/paleolithicera/registry/ModItems.kt
@@ -46,16 +46,28 @@ object ModItems {
     val PATCHED_HIDE: Item = register("patched_hide", { settings: Item.Settings -> Item(settings) })
 
     val HIDE_CAP: Item = register("hide_cap", { settings: Item.Settings ->
+        //? if >1.21.4 {
         Item(settings.armor(HIDE_MATERIAL, EquipmentType.HELMET))
+        //?} else {
+        /*ArmorItem(HIDE_MATERIAL, EquipmentType.HELMET, settings)*///?}
     })
     val HIDE_TUNIC: Item = register("hide_tunic", { settings: Item.Settings ->
+        //? if >1.21.4 {
         Item(settings.armor(HIDE_MATERIAL, EquipmentType.CHESTPLATE))
+        //?} else {
+        /*ArmorItem(HIDE_MATERIAL, EquipmentType.CHESTPLATE, settings)*///?}
     })
     val HIDE_LEGGINGS: Item = register("hide_leggings", { settings: Item.Settings ->
+        //? if >1.21.4 {
         Item(settings.armor(HIDE_MATERIAL, EquipmentType.LEGGINGS))
+        //?} else {
+        /*ArmorItem(HIDE_MATERIAL, EquipmentType.LEGGINGS, settings)*///?}
     })
     val HIDE_SHOES: Item = register("hide_shoes", { settings: Item.Settings ->
+        //? if >1.21.4 {
         Item(settings.armor(HIDE_MATERIAL, EquipmentType.BOOTS))
+        //?} else {
+        /*ArmorItem(HIDE_MATERIAL, EquipmentType.BOOTS, settings)*///?}
     })
 
     val WOODEN_SPEAR = register(
@@ -66,7 +78,10 @@ object ModItems {
                     .attributeModifiers(SpearItem.createAttributeModifiers(ToolMaterial.WOOD))
                     .component(DataComponentTypes.TOOL, SpearItem.createToolComponent(ToolMaterial.WOOD))
                     .enchantable(ToolMaterial.WOOD.enchantmentValue())
+                    //? if >1.21.4 {
                     .component(DataComponentTypes.WEAPON, WeaponComponent(1)),
+                    //?} else {
+                    /*,*///?}
                 ::WoodenSpearEntity
             )
         }
@@ -86,7 +101,10 @@ object ModItems {
                     .attributeModifiers(SpearItem.createAttributeModifiers(ModToolMaterials.BONE_MATERIAL))
                     .component(DataComponentTypes.TOOL, SpearItem.createToolComponent(ModToolMaterials.BONE_MATERIAL))
                     .enchantable(ModToolMaterials.BONE_MATERIAL.enchantmentValue())
+                    //? if >1.21.4 {
                     .component(DataComponentTypes.WEAPON, WeaponComponent(1)),
+                    //?} else {
+                    /*,*///?}
                 ::BoneSpearEntity
             )
         })

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -42,10 +42,10 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.16.14",
-    "minecraft": "~1.21.7",
+    "fabricloader": ">=${loader_version}",
+    "minecraft": "=${minecraft_version}",
     "java": ">=21",
-    "fabric-api": "0.129.0+1.21.7",
+    "fabric-api": "${fabric_version}",
     "fabric-language-kotlin": "${fabric_kotlin_version}"
   },
   "custom": {

--- a/src/test/kotlin/com/toolsandtaverns/paleolithicera/integration/ModMetadataTest.kt
+++ b/src/test/kotlin/com/toolsandtaverns/paleolithicera/integration/ModMetadataTest.kt
@@ -58,10 +58,12 @@ class ModMetadataTest {
     @Test
     fun `metadata requires the supported runtime versions`() {
         val dependencies = metadata.getAsJsonObject("depends")
+        val minecraftVersion = requireNotNull(System.getProperty("paleolithic.minecraftVersion"))
+        val loaderVersion = requireNotNull(System.getProperty("paleolithic.loaderVersion"))
 
         assertEquals(">=21", dependencies["java"].asString)
-        assertEquals("~1.21.7", dependencies["minecraft"].asString)
-        assertEquals(">=0.16.14", dependencies["fabricloader"].asString)
+        assertEquals("=$minecraftVersion", dependencies["minecraft"].asString)
+        assertEquals(">=$loaderVersion", dependencies["fabricloader"].asString)
         assertFalse(metadata["version"].asString.contains('$'), "resource placeholders must be expanded")
     }
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+	id("dev.kikugie.stonecutter")
+	id("net.fabricmc.fabric-loom-remap") version "1.14.10" apply false
+	kotlin("jvm") version "2.3.20" apply false
+}
+
+stonecutter active "1.21.7" /* [SC] DO NOT EDIT */

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
+loader_version=0.17.2
+fabric_version=0.119.4+1.21.4
+fabric_kotlin_version=1.13.10+kotlin.2.3.20

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.17.2
+fabric_version=0.128.2+1.21.5
+fabric_kotlin_version=1.13.10+kotlin.2.3.20

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.17.2
+fabric_version=0.128.2+1.21.6
+fabric_kotlin_version=1.13.10+kotlin.2.3.20

--- a/versions/1.21.7/gradle.properties
+++ b/versions/1.21.7/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.8
+loader_version=0.16.14
+fabric_version=0.129.0+1.21.7
+fabric_kotlin_version=1.13.10+kotlin.2.3.20


### PR DESCRIPTION
## Summary
- consolidate Minecraft 1.21.4 through 1.21.7 on one Stonecutter-managed source tree
- upgrade the Gradle, Loom, and Kotlin toolchain and add version-specific compatibility gates
- build and verify four exact-version runtime jars in CI
- keep shared datagen output owned by the 1.21.7 VCS node

## Motivation
Maintaining one branch per Minecraft version duplicated fixes and allowed the branches to drift. This makes `main` the single development line while preserving a tested jar for each supported version.

## Test plan
- `.\gradlew.bat --no-daemon build`
- `.\gradlew.bat --no-daemon :1.21.7:runDatagen`
- Stonecutter switch round-trip: `stonecutterSwitchTo1.21.4` then `stonecutterSwitchTo1.21.7`
- inspected all four runtime jars for exact Minecraft metadata and `LICENSE`

## Data and assets
Canonical 1.21.7 datagen completed with no generated-file changes. Older datagen tasks are disabled to protect the shared output tree.